### PR TITLE
Adds tests to cover the two excluded-fields fixes

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -213,10 +213,14 @@ class HistoricalRecords(object):
                 for field in fields.values()
             }
             if self.excluded_fields:
-                actual_model = self.instance_type.objects.get(pk=getattr(self, self.instance_type._meta.pk.attname))
-                for field in self.excluded_fields:
-                    attrs[field] = getattr(actual_model, field)
-
+                excluded_attnames = [
+                    model._meta.get_field(field).attname
+                    for field in self.excluded_fields
+                ]
+                values = model.objects.filter(
+                    pk=getattr(self, model._meta.pk.attname)
+                ).values(*excluded_attnames).get()
+                attrs.update(values)
             return model(**attrs)
 
         return {

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -22,6 +22,14 @@ class PollWithExcludeFields(models.Model):
     history = HistoricalRecords(excluded_fields=['pub_date'])
 
 
+class PollWithExcludedFKField(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField('date published')
+    place = models.ForeignKey('Place')
+
+    history = HistoricalRecords(excluded_fields=['place'])
+
+
 class Temperature(models.Model):
     location = models.CharField(max_length=200)
     temperature = models.IntegerField()

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -120,5 +120,3 @@ class TestPopulateHistory(TestCase):
                                 'tests.pollwithexcludefields', auto=True)
         update_record = models.PollWithExcludeFields.history.all()[0]
         self.assertEqual(update_record.question, poll.question)
-        with self.assertRaises(AttributeError):
-            update_record.pub_date

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -111,3 +111,14 @@ class TestPopulateHistory(TestCase):
                                     stdout=out)
         self.assertIn(populate_history.Command.NO_REGISTERED_MODELS,
                       out.getvalue())
+
+    def test_excluded_fields(self):
+        poll = models.PollWithExcludeFields.objects.create(
+            question="Will this work?", pub_date=datetime.now())
+        models.PollWithExcludeFields.history.all().delete()
+        management.call_command(self.command_name,
+                                'tests.pollwithexcludefields', auto=True)
+        update_record = models.PollWithExcludeFields.history.all()[0]
+        self.assertEqual(update_record.question, poll.question)
+        with self.assertRaises(AttributeError):
+            update_record.pub_date

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -809,7 +809,7 @@ class ExcludeForeignKeyTest(TestCase):
             historical.place
 
     def test_nb_queries(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             historical = self.get_first_historical()
             historical.instance
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -772,3 +772,12 @@ class CustomTableNameTest1(TestCase):
             self.get_table_name(ContactRegister.history),
             'contacts_register_history',
         )
+
+
+class ExcludeFieldsTest(TestCase):
+    def test_restore_pollwithexclude(self):
+        poll = PollWithExcludeFields.objects.create(question="what's up?",
+                                                    pub_date=today)
+        historical = poll.history.order_by('pk')[0]
+        original = historical.instance
+        self.assertEqual(original.pub_date, poll.pub_date)


### PR DESCRIPTION
The added tests relate to the useful fixes that you made for excluded-fields, @uadnan.  In particular, merging this should mean that coverage checks pass in [this PR of yours](https://github.com/treyhunner/django-simple-history/pull/304).