### PR TITLE
Revert "Bugfix: populate_history with an excluded fk-field"

### DIFF
--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -24,7 +24,7 @@ def bulk_history_create(model, history_model, batch_size):
             **{
                 field.attname: getattr(instance, field.attname)
                 for field in instance._meta.fields
-                if field.name not in history_model.excluded_fields
+                if field.attname not in history_model.excluded_fields
             }
         ) for instance in model.objects.all()]
     history_model.objects.bulk_create(historical_instances, batch_size=batch_size)

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -120,13 +120,3 @@ class TestPopulateHistory(TestCase):
                                 'tests.pollwithexcludefields', auto=True)
         update_record = models.PollWithExcludeFields.history.all()[0]
         self.assertEqual(update_record.question, poll.question)
-
-    def test_excluded_fk_field(self):
-        poll = models.PollWithExcludedFKField.objects.create(
-            question="Will this work?", pub_date=datetime.now(),
-            place=models.Place(name="Over the rainbow"))
-        models.PollWithExcludedFKField.history.all().delete()
-        management.call_command(self.command_name,
-                                'tests.pollwithexcludedfkfield', auto=True)
-        update_record = models.PollWithExcludedFKField.history.all()[0]
-        self.assertEqual(update_record.question, poll.question)


### PR DESCRIPTION
Reverts uadnan/django-simple-history#2

#2 Broked PopulateHistory tests. ll look into detail & fix later.